### PR TITLE
Markdown fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@
 
 # Lune 🌙
 
-	<div>
-
 [![Current Lune library version](https://img.shields.io/crates/v/lune.svg?label=Version)](https://crates.io/crates/lune)
-[![CI status](https://github.com/filiptibell/lune/workflows/ci/badge.svg)](https://github.com/filiptibell/lune/actions)
+[![CI status](https://github.com/filiptibell/lune/workflows/CI/badge.svg)](https://github.com/filiptibell/lune/actions)
 [![Release status](https://shields.io/endpoint?url=https://badges.readysetplay.io/workflow/filiptibell/lune/release.yaml)](https://github.com/filiptibell/lune/actions)
 [![Current Lune library version](https://img.shields.io/github/license/filiptibell/lune.svg?label=License&color=informational)](https://github.com/filiptibell/lune/blob/main/LICENSE.txt)
 
-	</div>
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,39 +2,35 @@
 <!-- markdownlint-disable MD041 -->
 
 <div align="center">
-	<h1> Lune 🌙 </h1>
+
+# Lune 🌙
+
 	<div>
-		<a href="https://crates.io/crates/lune">
-			<img src="https://img.shields.io/crates/v/lune.svg?label=Version" alt="Current Lune library version" />
-		</a>
-		<a href="https://github.com/filiptibell/lune/actions">
-			<img src="https://shields.io/endpoint?url=https://badges.readysetplay.io/workflow/filiptibell/lune/ci.yaml" alt="CI status" />
-		</a>
-		<a href="https://github.com/filiptibell/lune/actions">
-			<img src="https://shields.io/endpoint?url=https://badges.readysetplay.io/workflow/filiptibell/lune/release.yaml" alt="Release status" />
-		</a>
-		<a href="https://github.com/filiptibell/lune/blob/main/LICENSE.txt">
-			<img src="https://img.shields.io/github/license/filiptibell/lune.svg?label=License&color=informational" alt="Current Lune library version" />
-		</a>
+
+[![Current Lune library version](https://img.shields.io/crates/v/lune.svg?label=Version)](https://crates.io/crates/lune)
+[![CI status](https://github.com/filiptibell/lune/workflows/ci/badge.svg)](https://github.com/filiptibell/lune/actions)
+[![Release status](https://shields.io/endpoint?url=https://badges.readysetplay.io/workflow/filiptibell/lune/release.yaml)](https://github.com/filiptibell/lune/actions)
+[![Current Lune library version](https://img.shields.io/github/license/filiptibell/lune.svg?label=License&color=informational)](https://github.com/filiptibell/lune/blob/main/LICENSE.txt)
+
 	</div>
 </div>
 
-<hr />
+---
 
 Lune is a standalone [Luau](https://luau-lang.org) script runtime meant to be an alternative to traditional shell scripts, with the goal of drastically simplifying the typical tasks shell scripts are used for, making them easier to read and maintain.
 
-## Features
+## Features {#features}
 
 - A strictly minimal but powerful interface that is easy to read and remember, just like Lua itself
 - Fully featured APIs for the filesystem, networking, stdio, all included in the small (~2mb) executable
-- World-class documentation, on the web _or_ directly in your editor, no network connection necessary
+- World-class documentation, on the web *or* directly in your editor, no network connection necessary
 - A familiar scripting environment for Roblox developers, with an included 1-to-1 task scheduler port
 
-## Non-goals
+## Non-goals {#non-goals}
 
 - Making scripts short and terse - proper autocomplete / intellisense make scripting using Lune just as quick, and readability is important
 - Running full Roblox game scripts outside of Roblox - there is some compatibility here already, but Lune is meant for different purposes
 
-## Where do I start?
+## Where do I start? {#starting-guide}
 
 Head over to the [wiki](https://github.com/filiptibell/lune/wiki) to get started using Lune!


### PR DESCRIPTION
This does:

- Converted as much HTML to markdown as possible.
- Converted shields.io badge to use raw github badge (better and more accurate)
- Made italic use preferred syntax
- Gave all headings an ID so they can be linked to