### PR TITLE
Chaned horizontal rule from HTML to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 	</div>
 </div>
 
-<hr />
+---
 
 Lune is a standalone [Luau](https://luau-lang.org) script runtime meant to be an alternative to traditional shell scripts, with the goal of drastically simplifying the typical tasks shell scripts are used for, making them easier to read and maintain.
 


### PR DESCRIPTION
This superseeds #18.

As discussed in the previous pull mixing HTML and Markdown is bad for linting reasons. This ports the only change that doesn't mix HTML and markdown.