### PR TITLE
Start using new rbx_dom_weak instance cloning methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "rbx_binary"
 version = "0.7.0"
-source = "git+https://github.com/rojo-rbx/rbx-dom?rev=b6d255e0b5d96155f694ca224676b251059cf2de#b6d255e0b5d96155f694ca224676b251059cf2de"
+source = "git+https://github.com/rojo-rbx/rbx-dom?rev=e7a813d569c3f8a54be8a8873c33f8976c37b8b1#e7a813d569c3f8a54be8a8873c33f8976c37b8b1"
 dependencies = [
  "log",
  "lz4",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "rbx_dom_weak"
 version = "2.4.0"
-source = "git+https://github.com/rojo-rbx/rbx-dom?rev=b6d255e0b5d96155f694ca224676b251059cf2de#b6d255e0b5d96155f694ca224676b251059cf2de"
+source = "git+https://github.com/rojo-rbx/rbx-dom?rev=e7a813d569c3f8a54be8a8873c33f8976c37b8b1#e7a813d569c3f8a54be8a8873c33f8976c37b8b1"
 dependencies = [
  "rbx_types",
  "serde",
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "rbx_reflection"
 version = "4.2.0"
-source = "git+https://github.com/rojo-rbx/rbx-dom?rev=b6d255e0b5d96155f694ca224676b251059cf2de#b6d255e0b5d96155f694ca224676b251059cf2de"
+source = "git+https://github.com/rojo-rbx/rbx-dom?rev=e7a813d569c3f8a54be8a8873c33f8976c37b8b1#e7a813d569c3f8a54be8a8873c33f8976c37b8b1"
 dependencies = [
  "rbx_types",
  "serde",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "rbx_reflection_database"
 version = "0.2.6+roblox-572"
-source = "git+https://github.com/rojo-rbx/rbx-dom?rev=b6d255e0b5d96155f694ca224676b251059cf2de#b6d255e0b5d96155f694ca224676b251059cf2de"
+source = "git+https://github.com/rojo-rbx/rbx-dom?rev=e7a813d569c3f8a54be8a8873c33f8976c37b8b1#e7a813d569c3f8a54be8a8873c33f8976c37b8b1"
 dependencies = [
  "lazy_static",
  "rbx_reflection",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "rbx_types"
 version = "1.5.0"
-source = "git+https://github.com/rojo-rbx/rbx-dom?rev=b6d255e0b5d96155f694ca224676b251059cf2de#b6d255e0b5d96155f694ca224676b251059cf2de"
+source = "git+https://github.com/rojo-rbx/rbx-dom?rev=e7a813d569c3f8a54be8a8873c33f8976c37b8b1#e7a813d569c3f8a54be8a8873c33f8976c37b8b1"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "rbx_xml"
 version = "0.13.0"
-source = "git+https://github.com/rojo-rbx/rbx-dom?rev=b6d255e0b5d96155f694ca224676b251059cf2de#b6d255e0b5d96155f694ca224676b251059cf2de"
+source = "git+https://github.com/rojo-rbx/rbx-dom?rev=e7a813d569c3f8a54be8a8873c33f8976c37b8b1#e7a813d569c3f8a54be8a8873c33f8976c37b8b1"
 dependencies = [
  "base64 0.13.1",
  "log",

--- a/packages/lib-roblox/Cargo.toml
+++ b/packages/lib-roblox/Cargo.toml
@@ -22,11 +22,11 @@ thiserror.workspace = true
 glam = "0.24"
 rand = "0.8"
 
-rbx_binary = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "b6d255e0b5d96155f694ca224676b251059cf2de" }
-rbx_dom_weak = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "b6d255e0b5d96155f694ca224676b251059cf2de" }
-rbx_reflection = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "b6d255e0b5d96155f694ca224676b251059cf2de" }
-rbx_reflection_database = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "b6d255e0b5d96155f694ca224676b251059cf2de" }
-rbx_xml = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "b6d255e0b5d96155f694ca224676b251059cf2de" }
+rbx_binary = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "e7a813d569c3f8a54be8a8873c33f8976c37b8b1" }
+rbx_dom_weak = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "e7a813d569c3f8a54be8a8873c33f8976c37b8b1" }
+rbx_reflection = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "e7a813d569c3f8a54be8a8873c33f8976c37b8b1" }
+rbx_reflection_database = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "e7a813d569c3f8a54be8a8873c33f8976c37b8b1" }
+rbx_xml = { git = "https://github.com/rojo-rbx/rbx-dom", rev = "e7a813d569c3f8a54be8a8873c33f8976c37b8b1" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/packages/lib-roblox/src/instance/mod.rs
+++ b/packages/lib-roblox/src/instance/mod.rs
@@ -140,18 +140,14 @@ impl Instance {
         root of the weak dom, and return its referent.
     */
     pub fn clone_into_external_dom(self, external_dom: &mut WeakDom) -> DomRef {
-        let cloned = self.clone_instance();
-
-        let mut dom = INTERNAL_DOM
+        let dom = INTERNAL_DOM
             .try_write()
             .expect("Failed to get write access to document");
 
-        let internal_dom_ref = cloned.dom_ref;
-        let external_root_ref = external_dom.root_ref();
+        let cloned = dom.clone_into_external(self.dom_ref, external_dom);
+        external_dom.transfer_within(cloned, external_dom.root_ref());
 
-        dom.transfer(internal_dom_ref, external_dom, external_root_ref);
-
-        internal_dom_ref
+        cloned
     }
 
     /**


### PR DESCRIPTION
This PR changes `Instance::clone_into_external_dom` and `Instance::clone_instance` to start using the new cloning methods introduced in rojo-rbx/rbx-dom#312. The aim is to reduce complexity in Lune's implementation, and give the responsibility to rbx-dom instead. 