### PR TITLE
Use a read lock in clone_into_external_dom

### DIFF
--- a/packages/lib-roblox/src/instance/mod.rs
+++ b/packages/lib-roblox/src/instance/mod.rs
@@ -141,8 +141,8 @@ impl Instance {
     */
     pub fn clone_into_external_dom(self, external_dom: &mut WeakDom) -> DomRef {
         let dom = INTERNAL_DOM
-            .try_write()
-            .expect("Failed to get write access to document");
+            .try_read()
+            .expect("Failed to get read access to document");
 
         let cloned = dom.clone_into_external(self.dom_ref, external_dom);
         external_dom.transfer_within(cloned, external_dom.root_ref());


### PR DESCRIPTION
In #62, the fact that `WeakDom::clone_into_external` only requires read access to a source dom was overlooked. Acquiring a write lock to the internal dom is unnecessary, so this PR simply changes the `try_write` call here to `try_read`.