### PR TITLE
WebSocket objects do not allow for receiving and sending at the same time

### DIFF
--- a/packages/lib/src/lua/net/websocket.rs
+++ b/packages/lib/src/lua/net/websocket.rs
@@ -154,20 +154,20 @@ where
 {
     let mut ws = socket.write_stream.lock().await;
 
-    let _ = ws
-        .send(WsMessage::Close(Some(WsCloseFrame {
-            code: match code {
-                Some(code) if (1000..=4999).contains(&code) => WsCloseCode::from(code),
-                Some(code) => {
-                    return Err(LuaError::RuntimeError(format!(
-                        "Close code must be between 1000 and 4999, got {code}"
-                    )))
-                }
-                None => WsCloseCode::Normal,
-            },
-            reason: "".into(),
-        })))
-        .await;
+    ws.send(WsMessage::Close(Some(WsCloseFrame {
+        code: match code {
+            Some(code) if (1000..=4999).contains(&code) => WsCloseCode::from(code),
+            Some(code) => {
+                return Err(LuaError::RuntimeError(format!(
+                    "Close code must be between 1000 and 4999, got {code}"
+                )))
+            }
+            None => WsCloseCode::Normal,
+        },
+        reason: "".into(),
+    })))
+    .await
+    .map_err(LuaError::external)?;
 
     let res = ws.close();
     res.await.map_err(LuaError::external)

--- a/packages/lib/src/tests.rs
+++ b/packages/lib/src/tests.rs
@@ -58,6 +58,7 @@ create_tests! {
     net_serve_requests: "net/serve/requests",
     net_serve_websockets: "net/serve/websockets",
     net_socket_wss: "net/socket/wss",
+    net_socket_wss_rw: "net/socket/wss_rw",
 
     process_args: "process/args",
     process_cwd: "process/cwd",

--- a/tests/net/socket/wss-rw.luau
+++ b/tests/net/socket/wss-rw.luau
@@ -1,0 +1,26 @@
+local net = require("@lune/net")
+local process = require("@lune/process")
+local task = require("@lune/task")
+
+-- We're going to use Discord's WebSocket gateway server
+-- for testing that we can both read from a stream,
+-- as well as write to the same stream concurrently
+local socket = net.socket("wss://gateway.discord.gg/?v=10&encoding=json")
+
+task.spawn(function()
+	while not socket.closeCode do
+		socket.next()
+	end
+end)
+
+task.delay(1, function()
+	socket.send('{"op":1,"d":null}')
+	socket.close(1000)
+
+	process.exit(1)
+end)
+
+task.wait(5)
+
+task.defer(process.exit, 1)
+error("`socket.send` halted, failed to write to socket")

--- a/tests/net/socket/wss_rw.luau
+++ b/tests/net/socket/wss_rw.luau
@@ -7,20 +7,23 @@ local task = require("@lune/task")
 -- as well as write to the same stream concurrently
 local socket = net.socket("wss://gateway.discord.gg/?v=10&encoding=json")
 
-task.spawn(function()
+local spawnedThread = task.spawn(function()
 	while not socket.closeCode do
 		socket.next()
 	end
 end)
 
-task.delay(1, function()
-	socket.send('{"op":1,"d":null}')
-	socket.close(1000)
+local delayedThread = task.delay(5, function()
+	task.defer(process.exit, 1)
+	error("`socket.send` halted, failed to write to socket")
 
 	process.exit(1)
 end)
 
-task.wait(5)
+task.wait(1)
 
-task.defer(process.exit, 1)
-error("`socket.send` halted, failed to write to socket")
+socket.send('{"op":1,"d":null}')
+socket.close(1000)
+
+task.cancel(delayedThread)
+task.cancel(spawnedThread)


### PR DESCRIPTION
## Context
I've been stuck on an issue when writing my own Discord API Wrapper - I cant send and receive messages at the same time. This PR contains the changes i've made to enable the Lune application to send and receive messages at the same time.

## This PR
- Split the 'Socket' implementation into both a read/write set of streams.
- - This required partially refactoring the 'Close' function. 

https://github.com/filiptibell/lune/issues/66