### PR TITLE
Lune will fail to interpret code that begins with a <TAB>

### DIFF
--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -12,7 +12,7 @@ use tokio::{
 use crate::{
     setup::run_setup,
     utils::{
-        files::{discover_script_file_path_including_lune_dirs, strip_shebang},
+        files::discover_script_file_path_including_lune_dirs,
         listing::{find_lune_scripts, sort_lune_scripts, write_lune_scripts_list},
     },
 };
@@ -172,7 +172,7 @@ impl Cli {
         // Create a new lune object with all globals & run the script
         let result = Lune::new()
             .with_args(self.script_args)
-            .run(&script_display_name, strip_shebang(script_contents))
+            .run(&script_display_name, script_contents)
             .await;
         Ok(match result {
             Err(err) => {

--- a/packages/cli/src/utils/files.rs
+++ b/packages/cli/src/utils/files.rs
@@ -185,21 +185,3 @@ pub fn parse_lune_description_from_file(contents: &str) -> Option<String> {
         Some(unindented_lines)
     }
 }
-
-pub fn strip_shebang(mut contents: Vec<u8>) -> Vec<u8> {
-    if contents.starts_with(b"#!") {
-        if let Some(first_newline_idx) =
-            contents
-                .iter()
-                .enumerate()
-                .find_map(|(idx, c)| if *c == b'\n' { Some(idx) } else { None })
-        {
-            // NOTE: We keep the newline here on purpose to preserve
-            // correct line numbers in stack traces, the only reason
-            // we strip the shebang is to get the lua script to parse
-            // and the extra newline is not really a problem for that
-            contents.drain(..first_newline_idx);
-        }
-    }
-    contents
-}

--- a/packages/lib/src/lua/net/websocket.rs
+++ b/packages/lib/src/lua/net/websocket.rs
@@ -154,20 +154,20 @@ where
 {
     let mut ws = socket.write_stream.lock().await;
 
-    let _ = ws
-        .send(WsMessage::Close(Some(WsCloseFrame {
-            code: match code {
-                Some(code) if (1000..=4999).contains(&code) => WsCloseCode::from(code),
-                Some(code) => {
-                    return Err(LuaError::RuntimeError(format!(
-                        "Close code must be between 1000 and 4999, got {code}"
-                    )))
-                }
-                None => WsCloseCode::Normal,
-            },
-            reason: "".into(),
-        })))
-        .await;
+    ws.send(WsMessage::Close(Some(WsCloseFrame {
+        code: match code {
+            Some(code) if (1000..=4999).contains(&code) => WsCloseCode::from(code),
+            Some(code) => {
+                return Err(LuaError::RuntimeError(format!(
+                    "Close code must be between 1000 and 4999, got {code}"
+                )))
+            }
+            None => WsCloseCode::Normal,
+        },
+        reason: "".into(),
+    })))
+    .await
+    .map_err(LuaError::external)?;
 
     let res = ws.close();
     res.await.map_err(LuaError::external)

--- a/packages/lib/src/tests.rs
+++ b/packages/lib/src/tests.rs
@@ -58,6 +58,7 @@ create_tests! {
     net_serve_requests: "net/serve/requests",
     net_serve_websockets: "net/serve/websockets",
     net_socket_wss: "net/socket/wss",
+    net_socket_wss_rw: "net/socket/wss_rw",
 
     process_args: "process/args",
     process_cwd: "process/cwd",

--- a/tests/net/socket/wss-rw.luau
+++ b/tests/net/socket/wss-rw.luau
@@ -1,0 +1,26 @@
+local net = require("@lune/net")
+local process = require("@lune/process")
+local task = require("@lune/task")
+
+-- We're going to use Discord's WebSocket gateway server
+-- for testing that we can both read from a stream,
+-- as well as write to the same stream concurrently
+local socket = net.socket("wss://gateway.discord.gg/?v=10&encoding=json")
+
+task.spawn(function()
+	while not socket.closeCode do
+		socket.next()
+	end
+end)
+
+task.delay(1, function()
+	socket.send('{"op":1,"d":null}')
+	socket.close(1000)
+
+	process.exit(1)
+end)
+
+task.wait(5)
+
+task.defer(process.exit, 1)
+error("`socket.send` halted, failed to write to socket")

--- a/tests/net/socket/wss_rw.luau
+++ b/tests/net/socket/wss_rw.luau
@@ -7,20 +7,23 @@ local task = require("@lune/task")
 -- as well as write to the same stream concurrently
 local socket = net.socket("wss://gateway.discord.gg/?v=10&encoding=json")
 
-task.spawn(function()
+local spawnedThread = task.spawn(function()
 	while not socket.closeCode do
 		socket.next()
 	end
 end)
 
-task.delay(1, function()
-	socket.send('{"op":1,"d":null}')
-	socket.close(1000)
+local delayedThread = task.delay(5, function()
+	task.defer(process.exit, 1)
+	error("`socket.send` halted, failed to write to socket")
 
 	process.exit(1)
 end)
 
-task.wait(5)
+task.wait(1)
 
-task.defer(process.exit, 1)
-error("`socket.send` halted, failed to write to socket")
+socket.send('{"op":1,"d":null}')
+socket.close(1000)
+
+task.cancel(delayedThread)
+task.cancel(spawnedThread)


### PR DESCRIPTION
## Context
Calling `lua.load` with the contents of a file can lead to errors when interpreting file contents. This PR swaps out the original implementation to first compile file contents, and then load the bytecode of the compiled file contents.

## This PR
- Compile `script_contents` into lua bytecode, then feed the lua bytecode into `lua.load` function

https://github.com/filiptibell/lune/issues/70