### PR TITLE
Feature: Implement a REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,6 @@ dependencies = [
  "env_logger",
  "futures-util",
  "glam",
- "home",
  "hyper",
  "hyper-tungstenite",
  "include_dir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,21 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,16 +632,6 @@ checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
 dependencies = [
  "libc",
  "str-buf",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
 ]
 
 [[package]]
@@ -1112,7 +1087,6 @@ dependencies = [
  "directories",
  "dunce",
  "env_logger 0.10.0",
- "fancy-regex",
  "futures-util",
  "glam",
  "home",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +647,16 @@ checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
 dependencies = [
  "libc",
  "str-buf",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -1087,6 +1112,7 @@ dependencies = [
  "directories",
  "dunce",
  "env_logger 0.10.0",
+ "fancy-regex",
  "futures-util",
  "glam",
  "home",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,10 +625,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "flate2"
@@ -792,6 +830,15 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "http"
@@ -1042,6 +1089,7 @@ dependencies = [
  "env_logger 0.10.0",
  "futures-util",
  "glam",
+ "home",
  "hyper",
  "hyper-tungstenite",
  "include_dir",
@@ -1060,6 +1108,7 @@ dependencies = [
  "rbx_xml",
  "regex",
  "reqwest",
+ "rustyline",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1157,6 +1206,27 @@ dependencies = [
  "cfg-if",
  "luau0-src",
  "pkg-config",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1360,6 +1430,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1719,6 +1799,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustyline"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +2075,12 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
@@ -2337,6 +2446,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ lz4_flex = "0.11"
 pin-project = "1.0"
 os_str_bytes = "6.4"
 urlencoding = "2.1"
+home = "0.5.5"
 
 ### RUNTIME
 
@@ -119,6 +120,7 @@ regex = { optional = true, version = "1.7", default-features = false, features =
     "std",
     "unicode-perl",
 ] }
+rustyline = "12.0.0"
 
 ### ROBLOX
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ lz4_flex = "0.11"
 pin-project = "1.0"
 os_str_bytes = "6.4"
 urlencoding = "2.1"
-home = "0.5.5"
 
 ### RUNTIME
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ regex = { optional = true, version = "1.7", default-features = false, features =
     "std",
     "unicode-perl",
 ] }
+fancy-regex = "0.11.0"
 rustyline = "12.0.0"
 
 ### ROBLOX

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,18 +53,6 @@ opt-level = "z"
 strip = true
 lto = true
 
-[profile.dev]
-lto = "off"
-strip = "none"
-codegen-units = 256
-panic = "unwind"
-opt-level = 0
-incremental = true
-overflow-checks = true
-debug-assertions = true
-debug = true
-rpath = false
-
 # All of the dependencies for Lune.
 #
 # Dependencies are categorized as following:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,6 @@ regex = { optional = true, version = "1.7", default-features = false, features =
     "std",
     "unicode-perl",
 ] }
-fancy-regex = "0.11.0"
 rustyline = "12.0.0"
 
 ### ROBLOX

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,18 @@ opt-level = "z"
 strip = true
 lto = true
 
+[profile.dev]
+lto = "off"
+strip = "none"
+codegen-units = 256
+panic = "unwind"
+opt-level = 0
+incremental = true
+overflow-checks = true
+debug-assertions = true
+debug = true
+rpath = false
+
 # All of the dependencies for Lune.
 #
 # Dependencies are categorized as following:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,15 +1,10 @@
 use std::{
     fmt::Write as _,
-    io::ErrorKind,
-    path::PathBuf,
-    process::{exit, ExitCode},
+    process::ExitCode,
 };
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
-use rustyline::{
-    error::ReadlineError, Cmd, DefaultEditor, EventHandler, KeyCode, KeyEvent, Modifiers,
-};
 
 use lune::Lune;
 use tokio::{

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Write as _,
-    process::ExitCode,
-};
+use std::{fmt::Write as _, process::ExitCode};
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,13 @@
-use std::{fmt::Write as _, process::ExitCode};
+use std::{
+    fmt::Write as _,
+    io::ErrorKind,
+    path::PathBuf,
+    process::{exit, ExitCode},
+};
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
+use rustyline::{error::ReadlineError, DefaultEditor};
 
 use lune::Lune;
 use tokio::{
@@ -148,10 +154,92 @@ impl Cli {
             }
             // HACK: We know that we didn't get any arguments here but since
             // script_path is optional clap will not error on its own, to fix
-            // we will duplicate the cli command and make arguments required,
-            // which will then fail and print out the normal help message
+            // we will duplicate the CLI command and fetch the version of
+            // lune to display
             let cmd = Cli::command();
-            cmd.arg_required_else_help(true).get_matches();
+            let lune_version = cmd.get_version();
+
+            // The version is mandatory and will always exist
+            println!("Lune v{}", lune_version.unwrap());
+
+            let lune_instance = Lune::new();
+
+            let mut repl = DefaultEditor::new()?;
+
+            match repl.load_history(&(|| -> PathBuf {
+                let dir_opt = home::home_dir();
+
+                if let Some(dir) = dir_opt {
+                    dir.join(".lune_history")
+                } else {
+                    eprintln!("Failed to find user home directory, abort!");
+                    // Doesn't feel right to exit directly with a exit code of 1
+                    // Lmk if there is a better way of doing this
+                    exit(1);
+                }
+            })()) {
+                Ok(_) => (),
+                Err(err) => {
+                    match err {
+                        err => {
+                            if let ReadlineError::Io(io_err) = err {
+                                if io_err.kind() == ErrorKind::NotFound {
+                                    std::fs::write(
+                                        // We know for sure that the home dir already exists
+                                        home::home_dir().unwrap().join(".lune_history"),
+                                        String::new(),
+                                    )?;
+                                }
+                            }
+                        }
+                    }
+
+                    eprintln!("WARN: Failed to load REPL history")
+                }
+            };
+
+            let mut interrupt_counter = 0u32;
+
+            loop {
+                let mut source_code = String::new();
+
+                match repl.readline("> ") {
+                    Ok(code) => {
+                        source_code = code;
+
+                        // If source code eval was requested, we reset the counter
+                        interrupt_counter = 0;
+                    }
+
+                    Err(ReadlineError::Interrupted) => {
+                        // HACK: We actually want the user to do ^C twice to exit,
+                        // but the user would need to ^C one more time even after
+                        // the check passes, so we check for 1 instead of 2
+                        if interrupt_counter != 1 {
+                            println!("Interrupt: ^C again to exit");
+
+                            // Increment the counter
+                            interrupt_counter += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    Err(ReadlineError::Eof) => break,
+                    Err(err) => {
+                        eprintln!("REPL ERROR: {}", err.to_string());
+                        break;
+                    }
+                };
+
+                let eval_result = lune_instance.run("REPL", source_code).await;
+
+                match eval_result {
+                    Ok(_) => (),
+                    Err(err) => eprintln!("{}", err),
+                }
+            }
+
+            return Ok(ExitCode::SUCCESS);
         }
         // Figure out if we should read from stdin or from a file,
         // reading from stdin is marked by passing a single "-"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,9 @@ use std::{
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
-use rustyline::{error::ReadlineError, DefaultEditor};
+use rustyline::{
+    error::ReadlineError, Cmd, DefaultEditor, EventHandler, KeyCode, KeyEvent, Modifiers,
+};
 
 use lune::Lune;
 use tokio::{
@@ -198,6 +200,11 @@ impl Cli {
                 }
             };
 
+            // repl.bind_sequence(
+            //     KeyEvent(KeyCode::Enter, Modifiers::SHIFT),
+            //     EventHandler::Simple(Cmd::AcceptOrInsertLine { accept_in_the_middle: true }),
+            // );
+
             let mut interrupt_counter = 0u32;
 
             loop {
@@ -205,7 +212,8 @@ impl Cli {
 
                 match repl.readline("> ") {
                     Ok(code) => {
-                        source_code = code;
+                        source_code = code.clone();
+                        repl.add_history_entry(code.as_str())?;
 
                         // If source code eval was requested, we reset the counter
                         interrupt_counter = 0;

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -116,11 +116,6 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
             Ok(_) => (),
 
             Err(err) => {
-                println!("{}", err.to_string());
-
-                write!(&mut source_code, "{}", "\n")?;
-                prompt_kind = PromptState::Continuation;
-
                 eprintln!("{}", pretty_format_luau_error(&err.into_lua_err(), true))
             }
         };
@@ -132,7 +127,12 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
 fn save_repl_activity(mut repl: Editor<(), FileHistory>) -> Result<()> {
     // Once again, we know that the specified home directory
     // and history file already exist
-    repl.save_history(&directories::UserDirs::new().unwrap().home_dir().join(".lune_history"))?;
+    repl.save_history(
+        &directories::UserDirs::new()
+            .unwrap()
+            .home_dir()
+            .join(".lune_history"),
+    )?;
 
     Ok(())
 }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1,7 +1,6 @@
 use std::{
-    fmt::Write,
-    path::{Path, PathBuf},
-    process::{exit, ExitCode},
+    path::PathBuf,
+    process::ExitCode,
 };
 
 use anyhow::{Error, Result};

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::Error;
 use clap::Command;
-use fancy_regex::Regex;
+use regex::Regex;
 use lune::lua::stdio::formatting::{pretty_format_luau_error, pretty_format_value};
 use lune::Lune;
 use mlua::ExternalError;
@@ -77,14 +77,8 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode, Error> {
             !env_var_bool(no_color).unwrap_or_else(|| false)
         }
     });
-
-    // Group 2 of this match pattern is the variable contents
-
-    // We're using fancy_regex instead of regex for backreferences
-    // and lookaround. I'm not too good at regex, so if there's a
-    // way to do this without backreferences and lookarounds,
-    // please let me know.
-    const VARIABLE_DECLARATION_PAT: &str = r#"(?!local.*)(?!\s)(=\s*)(.*)"#;
+    
+    const VARIABLE_DECLARATION_PAT: &str = r#"(local)?\s*(.*)\s*(=)\s*(.*)\s*"#;
 
     // HACK: Prepend this "context" to the source code provided,
     // so that the variable is preserved even the following steps
@@ -138,7 +132,7 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode, Error> {
 
         match eval_result {
             Ok(_) => {
-                if Regex::new(VARIABLE_DECLARATION_PAT)?.is_match(&source_code)?
+                if Regex::new(VARIABLE_DECLARATION_PAT)?.is_match(&source_code)
                     && !&source_code.contains("\n")
                 {
                     let declaration = source_code.split("=").collect::<Vec<&str>>()[1]

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -95,7 +95,7 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
                     prompt_state = PromptState::Continuation;
                     source_code.push('\n')
                 } else {
-                    eprintln!("{}", err);
+                    eprintln!("{err}");
                 }
             }
         };

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -95,7 +95,7 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
             Err(err) => {
                 if err.is_incomplete_input() {
                     prompt_state = PromptState::Continuation;
-                    source_code.push_str("\n")
+                    source_code.push('\n')
                 } else {
                     eprintln!("{}", err);
                 }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -32,14 +32,7 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
         .join(".lune_history");
 
     if !history_file_path.exists() {
-        std::fs::write(
-            // We know for sure that the home dir already exists
-            directories::UserDirs::new()
-                .unwrap()
-                .home_dir()
-                .join(".lune_history"),
-            String::new(),
-        )?;
+        std::fs::write(&history_file_path, String::new())?;
     }
 
     repl.load_history(history_file_path)?;

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::PathBuf,
-    process::ExitCode,
-};
+use std::{path::PathBuf, process::ExitCode};
 
 use anyhow::{Error, Result};
 use clap::Command;

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1,0 +1,101 @@
+use std::{
+    io::{Error, ErrorKind},
+    path::PathBuf,
+    process::{exit, ExitCode},
+};
+
+use clap::Command;
+use lune::{Lune, LuneError};
+use rustyline::{error::ReadlineError, DefaultEditor};
+
+use super::Cli;
+
+// Isn't dependency injection plain awesome?!
+pub async fn show_interface(cmd: Command) -> Result<ExitCode, anyhow::Error> {
+    let lune_version = cmd.get_version();
+
+    // The version is mandatory and will always exist
+    println!("Lune v{}", lune_version.unwrap());
+
+    let lune_instance = Lune::new();
+
+    let mut repl = DefaultEditor::new()?;
+
+    match repl.load_history(&(|| -> PathBuf {
+        let dir_opt = home::home_dir();
+
+        if let Some(dir) = dir_opt {
+            dir.join(".lune_history")
+        } else {
+            eprintln!("Failed to find user home directory, abort!");
+            // Doesn't feel right to exit directly with a exit code of 1
+            // Lmk if there is a better way of doing this
+            exit(1);
+        }
+    })()) {
+        Ok(_) => (),
+        Err(err) => {
+            match err {
+                err => {
+                    if let ReadlineError::Io(io_err) = err {
+                        if io_err.kind() == ErrorKind::NotFound {
+                            std::fs::write(
+                                // We know for sure that the home dir already exists
+                                home::home_dir().unwrap().join(".lune_history"),
+                                String::new(),
+                            )?;
+                        }
+                    }
+                }
+            }
+
+            eprintln!("WARN: Failed to load REPL history")
+        }
+    };
+
+    let mut interrupt_counter = 0u32;
+
+    loop {
+        let mut source_code = String::new();
+
+        match repl.readline("> ") {
+            Ok(code) => {
+                source_code = code.clone();
+                repl.add_history_entry(code.as_str())?;
+
+                // If source code eval was requested, we reset the counter
+                interrupt_counter = 0;
+            }
+
+            Err(ReadlineError::Interrupted) => {
+                // HACK: We actually want the user to do ^C twice to exit,
+                // but the user would need to ^C one more time even after
+                // the check passes, so we check for 1 instead of 2
+                if interrupt_counter != 1 {
+                    println!("Interrupt: ^C again to exit");
+
+                    // Increment the counter
+                    interrupt_counter += 1;
+                } else {
+                    break;
+                }
+            }
+            Err(ReadlineError::Eof) => break,
+            Err(err) => {
+                eprintln!("REPL ERROR: {}", err.to_string());
+
+                // This isn't a good way to exit imo, once again
+                exit(1);
+            }
+        };
+
+        let eval_result = lune_instance.run("REPL", source_code).await;
+
+        match eval_result {
+            Ok(_) => (),
+            Err(err) => eprintln!("{}", err),
+        };
+    }
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -50,7 +50,7 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
         match repl.readline(prompt) {
             Ok(code) => {
                 if prompt_state == PromptState::Continuation {
-                    write!(&mut source_code, "{}", code)?;
+                    source_code.push_str(&code);
                 } else if prompt_state == PromptState::Regular {
                     source_code = code.clone();
                 }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -80,10 +80,8 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
                 break;
             }
             Err(err) => {
-                eprintln!("REPL ERROR: {}", err.to_string());
-
-                // This isn't a good way to exit imo, once again
-                exit(1);
+                eprintln!("REPL ERROR: {err}");
+                return Ok(ExitCode::FAILURE);
             }
         };
 

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    fmt::Write,
     io::ErrorKind,
     path::PathBuf,
     process::{exit, ExitCode},
@@ -7,19 +8,17 @@ use std::{
 
 use anyhow::Error;
 use clap::Command;
-use lune::{Lune, LuneError};
+use fancy_regex::Regex;
+use lune::lua::stdio::formatting::{pretty_format_luau_error, pretty_format_value};
+use lune::Lune;
 use mlua::ExternalError;
 use once_cell::sync::Lazy;
 use rustyline::{error::ReadlineError, history::FileHistory, DefaultEditor, Editor};
 
-use lune::lua::stdio::formatting::pretty_format_luau_error;
-
 fn env_var_bool(value: String) -> Option<bool> {
     match value.to_lowercase().as_str() {
-        "true" => Some(true),
-        "1" => Some(true),
-        "0" => Some(false),
-        "false" => Some(false),
+        "true" | "1" => Some(true),
+        "false" | "0" => Some(false),
         &_ => None,
     }
 }
@@ -73,18 +72,36 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode, Error> {
         let no_color = env::var("NO_COLOR").unwrap_or_else(|_| "false".to_string());
 
         if no_color.is_empty() {
-            false
+            true
         } else {
             !env_var_bool(no_color).unwrap_or_else(|| false)
         }
     });
+
+    // Group 2 of this match pattern is the variable contents
+
+    // We're using fancy_regex instead of regex for backreferences
+    // and lookaround. I'm not too good at regex, so if there's a
+    // way to do this without backreferences and lookarounds,
+    // please let me know.
+    const VARIABLE_DECLARATION_PAT: &str = r#"(?!local.*)(?!\s)(=\s*)(.*)"#;
+
+    // HACK: Prepend this "context" to the source code provided,
+    // so that the variable is preserved even the following steps
+    let mut source_code_context: Option<String> = None;
 
     loop {
         let mut source_code = String::new();
 
         match repl.readline("> ") {
             Ok(code) => {
-                source_code = code.clone();
+                if let Some(ref ctx) = source_code_context {
+                    // If something breaks, blame this
+                    source_code = format!("{}    {}", ctx, code);
+                } else {
+                    source_code.push_str(code.as_str());
+                }
+
                 repl.add_history_entry(code.as_str())?;
 
                 // If source code eval was requested, we reset the counter
@@ -117,10 +134,35 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode, Error> {
             }
         };
 
-        let eval_result = lune_instance.run("REPL", source_code).await;
+        let eval_result = lune_instance.run("REPL", source_code.clone()).await;
 
         match eval_result {
-            Ok(_) => (),
+            Ok(_) => {
+                if Regex::new(VARIABLE_DECLARATION_PAT)?.is_match(&source_code)?
+                    && !&source_code.contains("\n")
+                {
+                    let declaration = source_code.split("=").collect::<Vec<&str>>()[1]
+                        .trim()
+                        .replace("\"", "");
+
+                    let mut formatted_output = String::new();
+                    pretty_format_value(
+                        &mut formatted_output,
+                        &mlua::IntoLua::into_lua(declaration, &mlua::Lua::new())?,
+                        1,
+                    )?;
+
+                    source_code_context = (|| -> Result<Option<String>, Error> {
+                        let mut ctx = String::new();
+                        write!(&mut ctx, "{}\n", &source_code)?;
+
+                        Ok(Some(ctx))
+                    })()?;
+
+                    println!("{}", formatted_output);
+                }
+            }
+
             Err(err) => {
                 eprintln!(
                     "{}",

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt::Write,
     io::ErrorKind,
     path::PathBuf,
     process::{exit, ExitCode},
@@ -9,14 +8,9 @@ use anyhow::Result;
 use clap::Command;
 use directories::UserDirs;
 use lune::lua::stdio::formatting::pretty_format_luau_error;
-use lune::{Lune, LuneError};
+use lune::Lune;
 use mlua::ExternalError;
 use rustyline::{error::ReadlineError, history::FileHistory, DefaultEditor, Editor};
-
-enum PromptState {
-    Regular,
-    Continuation,
-}
 
 // Isn't dependency injection plain awesome?!
 pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
@@ -63,18 +57,12 @@ pub async fn show_interface(cmd: Command) -> Result<ExitCode> {
         }
     };
 
-    let mut prompt_kind: PromptState = PromptState::Regular;
     let mut interrupt_counter = 0u32;
 
     loop {
         let mut source_code = String::new();
 
-        let prompt = match prompt_kind {
-            PromptState::Regular => "> ",
-            PromptState::Continuation => ">> ",
-        };
-
-        match repl.readline(prompt) {
+        match repl.readline("> ") {
             Ok(code) => {
                 source_code = code.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod roblox;
 #[cfg(test)]
 mod tests;
 
-pub use crate::lune::{Lune, LuneError};
+pub use crate::lune::{lua, Lune, LuneError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,4 @@ pub mod roblox;
 #[cfg(test)]
 mod tests;
 
-pub use crate::lune::{lua, Lune, LuneError};
+pub use crate::lune::{Lune, LuneError};


### PR DESCRIPTION
As requested by users before, this PR includes a REPL functionality which is invoked when Lune is run with no positional arguments. The REPL currently supports
- Evaluation
- Clean exits (^C & ^D)
- Execution history 
- ~~Preservation of code "context" (variables declared in previous steps)~~
   - This has proven to be tough and should have a separate PR entirely dedicated to it. There are simply too many moving parts and is therefore out of scope for now.

What needs to be implemented/fixed:
- [x] ~~Context preservation for other declaratives (such as functions, or globals)~~
- [x] ~~Global variable detections for pretty printing~~
- [x] Allow user to enter additional code if the statement is incomplete

Closes #38.