### PR TITLE
Implement variadic versions of CFrame methods

### DIFF
--- a/src/roblox/datatypes/types/cframe.rs
+++ b/src/roblox/datatypes/types/cframe.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::ops;
 
 use glam::{EulerRot, Mat4, Quat, Vec3};
-use mlua::prelude::*;
+use mlua::{prelude::*, Variadic};
 use rbx_dom_weak::types::{CFrame as DomCFrame, Matrix3 as DomMatrix3, Vector3 as DomVector3};
 
 use super::{super::*, Vector3};
@@ -210,29 +210,46 @@ impl LuaUserData for CFrame {
                 translation,
             )))
         });
-        methods.add_method("ToWorldSpace", |_, this, rhs: LuaUserDataRef<CFrame>| {
-            Ok(*this * *rhs)
-        });
-        methods.add_method("ToObjectSpace", |_, this, rhs: LuaUserDataRef<CFrame>| {
-            Ok(this.inverse() * *rhs)
-        });
+        methods.add_method(
+            "ToWorldSpace",
+            |_, this, rhs: Variadic<LuaUserDataRef<CFrame>>| {
+                Ok(Variadic::from_iter(rhs.into_iter().map(|cf| *this * *cf)))
+            },
+        );
+        methods.add_method(
+            "ToObjectSpace",
+            |_, this, rhs: Variadic<LuaUserDataRef<CFrame>>| {
+                let inverse = this.inverse();
+                Ok(Variadic::from_iter(rhs.into_iter().map(|cf| inverse * *cf)))
+            },
+        );
         methods.add_method(
             "PointToWorldSpace",
-            |_, this, rhs: LuaUserDataRef<Vector3>| Ok(*this * *rhs),
+            |_, this, rhs: Variadic<LuaUserDataRef<Vector3>>| {
+                Ok(Variadic::from_iter(rhs.into_iter().map(|v3| *this * *v3)))
+            },
         );
         methods.add_method(
             "PointToObjectSpace",
-            |_, this, rhs: LuaUserDataRef<Vector3>| Ok(this.inverse() * *rhs),
+            |_, this, rhs: Variadic<LuaUserDataRef<Vector3>>| {
+                let inverse = this.inverse();
+                Ok(Variadic::from_iter(rhs.into_iter().map(|v3| inverse * *v3)))
+            },
         );
         methods.add_method(
             "VectorToWorldSpace",
-            |_, this, rhs: LuaUserDataRef<Vector3>| Ok((*this - Vector3(this.position())) * *rhs),
+            |_, this, rhs: Variadic<LuaUserDataRef<Vector3>>| {
+                let result = *this - Vector3(this.position());
+                Ok(Variadic::from_iter(rhs.into_iter().map(|v3| result * *v3)))
+            },
         );
         methods.add_method(
             "VectorToObjectSpace",
-            |_, this, rhs: LuaUserDataRef<Vector3>| {
-                let inv = this.inverse();
-                Ok((inv - Vector3(inv.position())) * *rhs)
+            |_, this, rhs: Variadic<LuaUserDataRef<Vector3>>| {
+                let inverse = this.inverse();
+                let result = inverse - Vector3(inverse.position());
+
+                Ok(Variadic::from_iter(rhs.into_iter().map(|v3| result * *v3)))
             },
         );
         #[rustfmt::skip]

--- a/tests/roblox/datatypes/CFrame.luau
+++ b/tests/roblox/datatypes/CFrame.luau
@@ -103,6 +103,9 @@ local offset = CFrame.new(0, 0, -5)
 assert(offset:ToWorldSpace(offset).Z == offset.Z * 2)
 assert(offset:ToObjectSpace(offset).Z == 0)
 
+assert(select("#", offset:ToWorldSpace(offset, offset, offset)) == 3)
+assert(select("#", offset:ToObjectSpace(offset, offset, offset)) == 3)
+
 local world = CFrame.fromOrientation(0, math.rad(90), 0) * CFrame.new(0, 0, -5)
 local world2 = CFrame.fromOrientation(0, -math.rad(90), 0) * CFrame.new(0, 0, -5)
 assertEq(CFrame.identity:ToObjectSpace(world), world)


### PR DESCRIPTION
Fixes #74

Now the below functions accept and return a variadic number of arguments.
```
CFrame:ToWorldSpace
CFrame:ToObjectSpace
CFrame:PointToWorldSpace
CFrame:PointToObjectSpace
CFrame:VectorToWorldSpace
CFrame:VectorToObjectSpace
```

Please let me know if there's any changes I should make or go about this another way.

I have added a test for ToWorldSpace and ToObjectSpace returning multiple values since they already have coverage, but left the other functions alone