### PR TITLE
Clone the root in Document::from_data_model_instance

### DIFF
--- a/tests/roblox/files/serializePlace.luau
+++ b/tests/roblox/files/serializePlace.luau
@@ -2,30 +2,56 @@ local fs = require("@lune/fs")
 local roblox = require("@lune/roblox")
 local Instance = roblox.Instance
 
-local game = Instance.new("DataModel")
+-- Smoke tests
 
-local workspace = game:GetService("Workspace")
+do
+	local game = Instance.new("DataModel")
 
-local model = Instance.new("Model")
-local part = Instance.new("Part")
+	local workspace = game:GetService("Workspace")
 
-part.Parent = model
-model.Parent = workspace
+	local model = Instance.new("Model")
+	local part = Instance.new("Part")
 
-local placeAsBinary = roblox.serializePlace(game)
-local placeAsXml = roblox.serializePlace(game, true)
+	part.Parent = model
+	model.Parent = workspace
 
-fs.writeFile("bin/temp-place.rbxl", placeAsBinary)
-fs.writeFile("bin/temp-place.rbxlx", placeAsXml)
+	local placeAsBinary = roblox.serializePlace(game)
+	local placeAsXml = roblox.serializePlace(game, true)
 
-local savedFileBinary = fs.readFile("bin/temp-place.rbxl")
-local savedFileXml = fs.readFile("bin/temp-place.rbxlx")
+	fs.writeFile("bin/temp-place.rbxl", placeAsBinary)
+	fs.writeFile("bin/temp-place.rbxlx", placeAsXml)
 
-local savedBinary = roblox.deserializePlace(savedFileBinary)
-local savedXml = roblox.deserializePlace(savedFileXml)
+	local savedFileBinary = fs.readFile("bin/temp-place.rbxl")
+	local savedFileXml = fs.readFile("bin/temp-place.rbxlx")
 
-assert(savedBinary.Name ~= "ROOT")
-assert(savedXml.Name ~= "ROOT")
+	local savedBinary = roblox.deserializePlace(savedFileBinary)
+	local savedXml = roblox.deserializePlace(savedFileXml)
 
-assert(savedBinary.ClassName == "DataModel")
-assert(savedXml.ClassName == "DataModel")
+	assert(savedBinary.Name ~= "ROOT")
+	assert(savedXml.Name ~= "ROOT")
+
+	assert(savedBinary.ClassName == "DataModel")
+	assert(savedXml.ClassName == "DataModel")
+end
+
+-- Ensure Ref properties are preserved across services
+do
+	local game = Instance.new("DataModel")
+	local ReplicatedStorage = Instance.new("ReplicatedStorage")
+	local Workspace = Instance.new("Workspace")
+
+	Workspace.Parent = game
+	ReplicatedStorage.Parent = game
+
+	local part = Instance.new("Part")
+	part.Parent = ReplicatedStorage
+
+	local objectValue = Instance.new("ObjectValue")
+	objectValue.Value = part
+	objectValue.Parent = Workspace
+
+	local serialized = roblox.serializePlace(game)
+	local deserialized = roblox.deserializePlace(serialized)
+
+	assert(deserialized.Workspace.ObjectValue.Value == deserialized.ReplicatedStorage.Part)
+end

--- a/tests/roblox/files/serializePlace.luau
+++ b/tests/roblox/files/serializePlace.luau
@@ -3,7 +3,6 @@ local roblox = require("@lune/roblox")
 local Instance = roblox.Instance
 
 -- Smoke tests
-
 do
 	local game = Instance.new("DataModel")
 


### PR DESCRIPTION
Closes #109 (this is squarely my bug :D).

This PR alters `Document::from_data_model_instance` to clone the root directly instead of cloning each child, thereby preserving Ref properties that point across children. rbx-dom can probably better support this use case, but I'll need to investigate what the best solution is

I think this may also be a problem for `Document::from_instance_array`... we might be able to do something similar to this PR and create a dummy instance, clone_within the entire instance array as children, then do the transfer+destroy dance?

Sorry about the test file diff - I opted to use `do` blocks to prevent variable shadowing. I can just use different variable names if preferred