### PR TITLE
Update to latest rbx-dom crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +862,18 @@ dependencies = [
  "libc",
  "redox_users 0.4.6",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1848,6 +1869,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,13 +2371,13 @@ dependencies = [
 
 [[package]]
 name = "rbx_binary"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9573fee5e073d7b303f475c285197fdc8179468de66ca60ee115a58fbac99296"
+checksum = "0d419f67c8012bf83569086e1208c541478b3b8e4f523deaa0b80d723fb5ef22"
 dependencies = [
  "ahash",
  "log",
- "lz4",
+ "lz4_flex",
  "profiling",
  "rbx_dom_weak",
  "rbx_reflection",
@@ -2373,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_dom_weak"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04425cf6e9376e5486f4fb35906c120d1b1b45618a490318cf563fab1fa230a9"
+checksum = "bc74878a4a801afc8014b14ede4b38015a13de5d29ab0095d5ed284a744253f6"
 dependencies = [
  "ahash",
  "rbx_types",
@@ -2385,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_reflection"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6d0d62baa613556b058a5f94a53b01cf0ccde0ea327ce03056e335b982e77e"
+checksum = "565dd3430991f35443fa6d23cc239fade2110c5089deb6bae5de77c400df4fd2"
 dependencies = [
  "rbx_types",
  "serde",
@@ -2396,11 +2426,12 @@ dependencies = [
 
 [[package]]
 name = "rbx_reflection_database"
-version = "1.0.3+roblox-670"
+version = "2.0.0+roblox-694"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22c05ef92528c0fb0cc580592a65ca178d3ea9beb07a1d9ca0a2503c4f3721c"
+checksum = "844ceb61f23bad59b06d7299b69ff276579316eafa9857981da3012a6223f663"
 dependencies = [
- "lazy_static",
+ "dirs 5.0.1",
+ "log",
  "rbx_reflection",
  "rmp-serde",
  "serde",
@@ -2408,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_types"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e4fdde46493def107e5f923d82e813dec9b3eef52c2f75fbad3a716023eda2"
+checksum = "03220ffce2bd06ad04f77a003cb807f2e5b2a18e97623066a5ac735a978398af"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
@@ -2423,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_xml"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb623833c31cc43bbdaeb32f5e91db8ecd63fc46e438d0d268baf9e61539cf1c"
+checksum = "be6c302cefe9c92ed09bcbb075cd24379271de135b0af331409a64c2ea3646ee"
 dependencies = [
  "ahash",
  "base64 0.13.1",
@@ -3316,6 +3347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3754,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3749,6 +3795,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3795,6 +3856,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3807,6 +3874,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3816,6 +3889,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3843,6 +3922,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3852,6 +3937,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3867,6 +3958,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3876,6 +3973,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/lune-roblox/Cargo.toml
+++ b/crates/lune-roblox/Cargo.toml
@@ -23,10 +23,10 @@ glam = "0.30"
 rand = "0.9"
 thiserror = "2.0"
 
-rbx_binary = "1.0"
-rbx_dom_weak = "3.0"
-rbx_reflection = "5.0"
-rbx_reflection_database = "1.0"
-rbx_xml = "1.0"
+rbx_binary = "2.0"
+rbx_dom_weak = "4.0"
+rbx_reflection = "6.0"
+rbx_reflection_database = "2.0"
+rbx_xml = "2.0"
 
 lune-utils = { version = "0.3.3", optional = true, path = "../lune-utils" }

--- a/crates/lune-roblox/src/datatypes/extension.rs
+++ b/crates/lune-roblox/src/datatypes/extension.rs
@@ -49,6 +49,7 @@ impl DomValueExt for DomType {
             Vector3int16 => "Vector3int16",
             OptionalCFrame => "OptionalCFrame",
             SecurityCapabilities => "SecurityCapabilities",
+            NetAssetRef => "NetAssetRef",
             _ => return None,
         })
     }

--- a/crates/lune-roblox/src/datatypes/types/content.rs
+++ b/crates/lune-roblox/src/datatypes/types/content.rs
@@ -24,7 +24,7 @@ impl LuaExportsTable for Content {
         let from_uri = |_: &Lua, uri: String| Ok(Self(ContentType::Uri(uri)));
 
         let from_object = |_: &Lua, obj: LuaUserDataRef<Instance>| {
-            let database = rbx_reflection_database::get();
+            let database = rbx_reflection_database::get().unwrap();
             let instance_descriptor = database
                 .classes
                 .get("Instance")

--- a/crates/lune-roblox/src/datatypes/types/enum.rs
+++ b/crates/lune-roblox/src/datatypes/types/enum.rs
@@ -17,7 +17,7 @@ pub struct Enum {
 
 impl Enum {
     pub(crate) fn from_name(name: impl AsRef<str>) -> Option<Self> {
-        let db = rbx_reflection_database::get();
+        let db = rbx_reflection_database::get().unwrap();
         db.enums.get(name.as_ref()).map(Enum::from)
     }
 }

--- a/crates/lune-roblox/src/datatypes/types/enums.rs
+++ b/crates/lune-roblox/src/datatypes/types/enums.rs
@@ -16,7 +16,7 @@ impl LuaUserData for Enums {
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
         // Methods
         methods.add_method("GetEnums", |_, _, ()| {
-            let db = rbx_reflection_database::get();
+            let db = rbx_reflection_database::get().unwrap();
             Ok(db.enums.values().map(Enum::from).collect::<Vec<_>>())
         });
         methods.add_meta_method(

--- a/crates/lune-roblox/src/datatypes/types/physical_properties.rs
+++ b/crates/lune-roblox/src/datatypes/types/physical_properties.rs
@@ -45,7 +45,7 @@ impl LuaExportsTable for PhysicalProperties {
 
     fn create_exports_table(lua: Lua) -> LuaResult<LuaTable> {
         type ArgsMaterial = LuaUserDataRef<EnumItem>;
-        type ArgsNumbers = (f32, f32, f32, Option<f32>, Option<f32>, f32);
+        type ArgsNumbers = (f32, f32, f32, Option<f32>, Option<f32>, Option<f32>);
 
         let physical_properties_new = |lua: &Lua, args: LuaMultiValue| {
             if let Ok(value) = ArgsMaterial::from_lua_multi(args.clone(), lua) {
@@ -69,7 +69,7 @@ impl LuaExportsTable for PhysicalProperties {
                 elasticity,
                 friction_weight,
                 elasticity_weight,
-                acoustic_absorbption,
+                acoustic_absorption,
             )) = ArgsNumbers::from_lua_multi(args, lua)
             {
                 Ok(PhysicalProperties {
@@ -78,7 +78,7 @@ impl LuaExportsTable for PhysicalProperties {
                     friction_weight: friction_weight.unwrap_or(1.0),
                     elasticity,
                     elasticity_weight: elasticity_weight.unwrap_or(1.0),
-                    acoustic_absorption: acoustic_absorbption,
+                    acoustic_absorption: acoustic_absorption.unwrap_or(1.0),
                 })
             } else {
                 // FUTURE: Better error message here using given arg types
@@ -101,6 +101,7 @@ impl LuaUserData for PhysicalProperties {
         fields.add_field_method_get("FrictionWeight", |_, this| Ok(this.friction_weight));
         fields.add_field_method_get("Elasticity", |_, this| Ok(this.elasticity));
         fields.add_field_method_get("ElasticityWeight", |_, this| Ok(this.elasticity_weight));
+        fields.add_field_method_get("AcousticAbsorption", |_, this| Ok(this.acoustic_absorption));
     }
 
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {

--- a/crates/lune-roblox/src/instance/registry.rs
+++ b/crates/lune-roblox/src/instance/registry.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use mlua::{prelude::*, AppDataRef};
+use mlua::{AppDataRef, prelude::*};
 use thiserror::Error;
 
 use super::Instance;

--- a/crates/lune-roblox/src/instance/registry.rs
+++ b/crates/lune-roblox/src/instance/registry.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use mlua::{AppDataRef, prelude::*};
+use mlua::{prelude::*, AppDataRef};
 use thiserror::Error;
 
 use super::Instance;
@@ -248,7 +248,7 @@ impl InstanceRegistry {
 */
 #[must_use]
 pub fn class_name_chain(class_name: &str) -> Vec<&str> {
-    let db = rbx_reflection_database::get();
+    let db = rbx_reflection_database::get().unwrap();
 
     let mut list = vec![class_name];
     let mut current_name = class_name;

--- a/crates/lune-roblox/src/reflection/mod.rs
+++ b/crates/lune-roblox/src/reflection/mod.rs
@@ -135,7 +135,7 @@ impl LuaUserData for Database {
 
 impl Default for Database {
     fn default() -> Self {
-        Self(rbx_reflection_database::get())
+        Self(rbx_reflection_database::get().unwrap())
     }
 }
 

--- a/crates/lune-roblox/src/shared/instance.rs
+++ b/crates/lune-roblox/src/shared/instance.rs
@@ -25,7 +25,7 @@ pub(crate) fn find_property_info(
     instance_class: impl AsRef<str>,
     property_name: impl AsRef<str>,
 ) -> Option<PropertyInfo> {
-    let db = rbx_reflection_database::get();
+    let db = rbx_reflection_database::get().unwrap();
 
     let instance_class = instance_class.as_ref();
     let property_name = property_name.as_ref();
@@ -103,7 +103,7 @@ pub(crate) fn find_property_info(
     Checks if an instance class exists in the reflection database.
 */
 pub fn class_exists(class_name: impl AsRef<str>) -> bool {
-    let db = rbx_reflection_database::get();
+    let db = rbx_reflection_database::get().unwrap();
     db.classes.contains_key(class_name.as_ref())
 }
 
@@ -122,7 +122,7 @@ pub fn class_is_a(instance_class: impl AsRef<str>, class_name: impl AsRef<str>) 
     if class_name == "Instance" || instance_class == class_name {
         Some(true)
     } else {
-        let db = rbx_reflection_database::get();
+        let db = rbx_reflection_database::get().unwrap();
 
         while instance_class != class_name {
             let class_descriptor = db.classes.get(instance_class)?;
@@ -149,7 +149,7 @@ pub fn class_is_a(instance_class: impl AsRef<str>, class_name: impl AsRef<str>) 
 pub fn class_is_a_service(instance_class: impl AsRef<str>) -> Option<bool> {
     let mut instance_class = instance_class.as_ref();
 
-    let db = rbx_reflection_database::get();
+    let db = rbx_reflection_database::get().unwrap();
 
     loop {
         let class_descriptor = db.classes.get(instance_class)?;

--- a/scripts/physical_properties_enum_map.luau
+++ b/scripts/physical_properties_enum_map.luau
@@ -10,18 +10,19 @@ for _, enum in Enum.Material:GetEnumItems() do
 	longestNameLen = math.max(longestNameLen, #enum.Name)
 end
 
-contents ..= "\n#[rustfmt::skip]\nconst MATERIAL_ENUM_MAP: &[(&str, f32, f32, f32, f32, f32)] = &[\n"
+contents ..= "\n#[rustfmt::skip]\nconst MATERIAL_ENUM_MAP: &[(&str, f32, f32, f32, f32, f32, f32)] = &[\n"
 for _, enum in Enum.Material:GetEnumItems() do
 	local props = PhysicalProperties.new(enum)
 	contents ..= string.format(
-		'    ("%s",%s %.2f, %.2f, %.2f, %.2f, %.2f),\n',
+		'    ("%s",%s %.2f, %.2f, %.2f, %.2f, %.2f, %.2f),\n',
 		enum.Name,
 		string.rep(" ", longestNameLen - #enum.Name),
 		props.Density,
 		props.Friction,
 		props.Elasticity,
 		props.FrictionWeight,
-		props.ElasticityWeight
+		props.ElasticityWeight,
+		props.AcousticAbsorption
 	)
 end
 contents ..= "];\n"

--- a/tests/roblox/datatypes/PhysicalProperties.luau
+++ b/tests/roblox/datatypes/PhysicalProperties.luau
@@ -26,12 +26,14 @@ end))
 
 assert(PhysicalProperties.new(1, 2, 3).FrictionWeight == 1)
 assert(PhysicalProperties.new(1, 2, 3).ElasticityWeight == 1)
+assert(PhysicalProperties.new(1, 2, 3).AcousticAbsorption == 1)
 
-assert(PhysicalProperties.new(1, 2, 3, 4, 5).Density == 1)
-assert(PhysicalProperties.new(1, 2, 3, 4, 5).Friction == 2)
-assert(PhysicalProperties.new(1, 2, 3, 4, 5).Elasticity == 3)
-assert(PhysicalProperties.new(1, 2, 3, 4, 5).FrictionWeight == 4)
-assert(PhysicalProperties.new(1, 2, 3, 4, 5).ElasticityWeight == 5)
+assert(PhysicalProperties.new(1, 2, 3, 4, 5, 6).Density == 1)
+assert(PhysicalProperties.new(1, 2, 3, 4, 5, 6).Friction == 2)
+assert(PhysicalProperties.new(1, 2, 3, 4, 5, 6).Elasticity == 3)
+assert(PhysicalProperties.new(1, 2, 3, 4, 5, 6).FrictionWeight == 4)
+assert(PhysicalProperties.new(1, 2, 3, 4, 5, 6).ElasticityWeight == 5)
+assert(PhysicalProperties.new(1, 2, 3, 4, 5, 6).AcousticAbsorption == 6)
 
 local function fuzzyEq(n0: number, n1: number)
 	return math.abs(n1 - n0) <= 0.0001
@@ -53,6 +55,7 @@ assert(fuzzyEq(sand.Friction, 0.5))
 assert(fuzzyEq(sand.Elasticity, 0.05))
 assert(fuzzyEq(sand.FrictionWeight, 5))
 assert(fuzzyEq(sand.ElasticityWeight, 2.5))
+assert(fuzzyEq(sand.AcousticAbsorption, 0.55))
 
 -- Ops
 

--- a/tests/roblox/reflection/enums.luau
+++ b/tests/roblox/reflection/enums.luau
@@ -28,5 +28,9 @@ for _, enumName in db:GetEnumNames() do
 		)
 		empty = false
 	end
-	assert(not empty, "Enum items map must not be empty")
+	-- As of October 12 2025, the enum AudioCaptureMode is empty in Roblox API dumps.
+	-- TODO: Remove this if statement when AudioCaptureMode becomes non-empty.
+	if enumName ~= "AudioCaptureMode" then
+		assert(not empty, "Enum items map must not be empty")
+	end
 end


### PR DESCRIPTION
This PR updates the lune-roblox crate to use the latest batch of releases from rbx-dom. There were some breaking changes in rbx_types and rbx_reflection_database, which are summarized [here](https://github.com/rojo-rbx/rbx-dom/blob/master/rbx_types/CHANGELOG.md#300-2025-10-10) and [here](https://github.com/rojo-rbx/rbx-dom/blob/master/rbx_reflection_database/CHANGELOG.md#200roblox-694-2025-10-10).