### PR TITLE
Fix close method on child writer not closing

### DIFF
--- a/tests/process/create/stream.luau
+++ b/tests/process/create/stream.luau
@@ -9,6 +9,9 @@ catChild.stdin:write(expected)
 catChild.stdin:close()
 local catOutput = catChild.stdout:read(#expected)
 
+-- Make sure the child exits
+catChild:status()
+
 assert(
 	expected == catOutput,
 	"Failed to write to stdin or read from stdout of child process!"


### PR DESCRIPTION
Fixes a bug where `child.stdin:close()` on a child process created by `process.create()` did not actually close the `stdin`, this caused processes which read from stdin until EOF to wait indefinitely.

On Unix, calling `close` on `async-process::ChildStdin` does not actually close the underyling writer. This is due to it using `async_io::Async` under the hood on Unix, whose [`close` implementation just flushes the underlying writer](https://docs.rs/async-io/latest/async_io/struct.Async.html#closing).

This has been fixed dropping the `ChildStdin` on close, which will close the underlying writer. The internals of the child writer have also been refactored a bit. An existing test has been updated to catch this bug.