### PR TITLE
fix: ColorSequence.new() parse two-arg before single-arg

### DIFF
--- a/crates/lune-roblox/src/datatypes/types/color_sequence.rs
+++ b/crates/lune-roblox/src/datatypes/types/color_sequence.rs
@@ -30,20 +30,10 @@ impl LuaExportsTable for ColorSequence {
         type ArgsKeypoints = Vec<LuaUserDataRef<ColorSequenceKeypoint>>;
 
         let color_sequence_new = |lua: &Lua, args: LuaMultiValue| {
-            if let Ok(color) = ArgsColor::from_lua_multi(args.clone(), lua) {
-                Ok(ColorSequence {
-                    keypoints: vec![
-                        ColorSequenceKeypoint {
-                            time: 0.0,
-                            color: *color,
-                        },
-                        ColorSequenceKeypoint {
-                            time: 1.0,
-                            color: *color,
-                        },
-                    ],
-                })
-            } else if let Ok((c0, c1)) = ArgsColors::from_lua_multi(args.clone(), lua) {
+            // Try two-arg first: ColorSequence.new(startColor, endColor)
+            // Must come before single-arg because from_lua_multi for a single
+            // userdata ref succeeds even when multiple args are passed (ignoring extras).
+            if let Ok((c0, c1)) = ArgsColors::from_lua_multi(args.clone(), lua) {
                 Ok(ColorSequence {
                     keypoints: vec![
                         ColorSequenceKeypoint {
@@ -53,6 +43,20 @@ impl LuaExportsTable for ColorSequence {
                         ColorSequenceKeypoint {
                             time: 1.0,
                             color: *c1,
+                        },
+                    ],
+                })
+            } else if let Ok(color) = ArgsColor::from_lua_multi(args.clone(), lua) {
+                // Single-arg: ColorSequence.new(color) — uniform color
+                Ok(ColorSequence {
+                    keypoints: vec![
+                        ColorSequenceKeypoint {
+                            time: 0.0,
+                            color: *color,
+                        },
+                        ColorSequenceKeypoint {
+                            time: 1.0,
+                            color: *color,
                         },
                     ],
                 })


### PR DESCRIPTION
## Summary
- Reorder `ColorSequence.new()` argument parsing to try two-arg `(startColor, endColor)` before single-arg `(color)`.
- `from_lua_multi` for a single userdata ref silently succeeds even when multiple args are passed (ignoring extras), so the two-arg overload must be tried first to avoid discarding the second color.

## Test plan
- [ ] Verify `ColorSequence.new(Color3.new(1,0,0), Color3.new(0,0,1))` produces correct start/end keypoints
- [ ] Verify `ColorSequence.new(Color3.new(1,0,0))` still works for uniform color

🤖 Generated with [Claude Code](https://claude.com/claude-code)