### PR TITLE
Fix `socket:close()` always erroring and the tcp info test on IPv6 networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the `close` method on web sockets always erroring with "Socket has been closed" instead of closing the socket
+
 ## `0.10.5` - July 2nd, 2026
 
 ### Added

--- a/crates/lune-std-net/src/shared/websocket.rs
+++ b/crates/lune-std-net/src/shared/websocket.rs
@@ -98,13 +98,15 @@ where
         // the closure even if `next` is never called by the user
         self.set_close_code_if_unset(code);
 
-        self.send(TungsteniteMessage::Close(Some(CloseFrame {
+        // `send` rejects everything once a close code has been recorded
+        let mut ws = self.write_stream.lock().await;
+        ws.send(TungsteniteMessage::Close(Some(CloseFrame {
             code: CloseCode::from(code),
             reason: "".into(),
         })))
-        .await?;
+        .await
+        .into_lua_err()?;
 
-        let mut ws = self.write_stream.lock().await;
         ws.close().await.into_lua_err()
     }
 }

--- a/tests/net/tcp/info.luau
+++ b/tests/net/tcp/info.luau
@@ -7,10 +7,16 @@ assert(type(stream.localPort) == "number", "localPort should be a number")
 assert(type(stream.remoteIp) == "string", "remoteIp should be a string")
 assert(stream.remotePort == 80, "remotePort should be 80")
 
-assert(
-	string.match(stream.remoteIp, "^%d+%.%d+%.%d+%.%d+$"),
-	"remoteIp should be a valid IP address"
-)
+-- connection may be made over IPv4 or IPv6
+local function isIpAddress(ip: string): boolean
+	if string.match(ip, "^%d+%.%d+%.%d+%.%d+$") then
+		return true -- IPv4
+	end
+	-- IPv6
+	return string.find(ip, ":") ~= nil and string.match(ip, "^[%x:%.]+$") ~= nil
+end
+
+assert(isIpAddress(stream.remoteIp), "remoteIp should be a valid IP address")
 
 assert(stream.localPort > 0 and stream.localPort <= 65535, "localPort should be in valid range")
 


### PR DESCRIPTION
`close` records the close code first, then sends its close frame through `send`, which rejects anything once a close code is recorded. So every `socket:close()` errored with "Socket has been closed" without actually closing, which is also why the websocket tests failed. The close frame is now written to the write stream directly. `closeCode` still follows RFC 6455 (#182)

The tcp info test also failed on networks that preferred IPv6 as it asserted only IPv4 addresses for `remoteIp`, but httpbingo.org resolves to IPv6 where available